### PR TITLE
fix: fix react router doesn't work on vercel

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "rewrites": [{ "source": "/(.*)", "destination": "/" }]
+}


### PR DESCRIPTION
新增 vercel.json 檔，解決 react router 無法在 vercel 上成功的原因