### PR TITLE
Feature/api forced change alo6

### DIFF
--- a/src/apis/apis.ts
+++ b/src/apis/apis.ts
@@ -4,7 +4,8 @@ const getToken = () => {
   const token = localStorage.getItem("authToken");
   const config = {
     headers: {
-      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+      "Authorization": `Bearer ${token}`,
     },
   };
   return config;
@@ -66,13 +67,15 @@ export const apiHouseLandlordPostDelete = (houseId: string|null) => houseRequest
 export const apiHouseLandlordList = () => houseRequest.get('/landlord/list',getToken()); // ALO-1
 export const apiHouseLandlordSingleInfo = (houseId: string|undefined) => houseRequest.get(`/landlord/info/${houseId}`,getToken()); // ALO-12、ALO-13、ALO-14、ALO-15
 
+// 房源-房東更改房源狀態相關
+export const apiHouseLandlordFindUser = (tenantPhone: string) => houseRequest.post('/landlord/userInfo', tenantPhone, getToken()); // ALO-9
+export const apiHouseLandlordChangeFinish = (houseId: string|null) => houseRequest.patch(`/landlord/status/${houseId}`, {}, getToken()); // ALO-6
+
 // 房源-房東相關的 api
 export const apiHouseLandlordContract = () => houseRequest.get('/landlord/contract'); // ALO-16
 export const apiHouseLandlordSingleContract = (id: string) => houseRequest.post(`/landlord/contract/${id}`); // ALO-7
-export const apiHouseLandlordChangeStatus = (id: string) => houseRequest.patch(`/landlord/status/${id}`); // ALO-6
 export const apiHouseLandlordAddTenant = (data: any) => houseRequest.post('/landlord/userinfo', data); // ALO-5
 export const apiHouseLandlordUnratedCount = () => houseRequest.get('/landlord/count/unrated'); // ALO-10
-export const apiHouseLandlordFindUser = (data: any) => houseRequest.post('/landlord/userinfo', data); // ALO-9
 export const apiHouseLandlordForceChange = (data: any) => houseRequest.post('/landlord/userinfo', data); // ALO-8
 
 // 房源-搜尋頁面相關的 api

--- a/src/components/landLordManagement/index/HouseCard.tsx
+++ b/src/components/landLordManagement/index/HouseCard.tsx
@@ -69,6 +69,7 @@ export default function HouseCard({data, houseStatus}: {data:any, houseStatus:st
   const handleButtonClick = (event: React.MouseEvent<HTMLButtonElement>) => {
     if ( houseStatus === "publishList" ) {
       event.stopPropagation();
+      localStorage.setItem("houseId", houseId);
       setOpenModal(true);
     }
   }

--- a/src/components/landLordManagement/index/HouseCard.tsx
+++ b/src/components/landLordManagement/index/HouseCard.tsx
@@ -90,6 +90,7 @@ export default function HouseCard({data, houseStatus}: {data:any, houseStatus:st
         console.log(error);
       }
     } else if ( houseStatus === "publishList" ) {
+      localStorage.setItem("houseId", houseId);
       navigate(`/landlord/publish/${houseId}`);
     }
     setLoading(false);
@@ -102,7 +103,7 @@ export default function HouseCard({data, houseStatus}: {data:any, houseStatus:st
       }
       <li
         data-house-id={houseId}
-        className="col-span-3 p-4 rounded-[20px] bg-white hover:bg-Landlord-99"
+        className="cursor-pointer col-span-3 p-4 rounded-[20px] bg-white hover:bg-Landlord-99"
         onClick={handleCardClick}
       >
         <div className="overflow-hidden rounded-2xl mb-4 h-48">

--- a/src/components/landLordManagement/index/HouseList.tsx
+++ b/src/components/landLordManagement/index/HouseList.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, createContext } from "react";
 import { useNavigate } from "react-router-dom";
 import { CustomFlowbiteTheme, Flowbite, Accordion, AccordionContent, AccordionPanel, AccordionTitle, Tooltip } from "flowbite-react";
 import LandlordAnchor from "./LandlordAnchor";
@@ -17,6 +17,16 @@ export interface listCountType {
   rented : number,
   finished : number
 }
+
+// 定義 ForcedChangeReload 的型別
+interface contextValueType {
+  isforcedChangeAPITriggered: boolean;
+  setIsforcedChangeAPITriggered: (value: boolean) => void;
+}
+
+export const ForcedChangeReload = createContext<contextValueType>(
+  {} as contextValueType
+);
 
 export default function HouseList() {
   const customTheme: CustomFlowbiteTheme = {
@@ -153,6 +163,13 @@ export default function HouseList() {
     goFinishedList,
   }
 
+  // 當強制變更觸發時，更改 false 為 true
+  const [isforcedChangeAPITriggered, setIsforcedChangeAPITriggered] = useState(false);
+  const contextValue = {
+    isforcedChangeAPITriggered,
+    setIsforcedChangeAPITriggered,
+  };
+
   useEffect(() => {
     const getHouseList = async () => {
       setLoading(true);
@@ -170,7 +187,8 @@ export default function HouseList() {
       }
     }
     getHouseList();
-  },[navigate])
+    return setIsforcedChangeAPITriggered(false);
+  },[navigate,isforcedChangeAPITriggered])
 
   return (
     <>
@@ -178,6 +196,7 @@ export default function HouseList() {
         loading && <BigLoading />
       }
       <main className="container mt-14 mb-32">
+      <ForcedChangeReload.Provider value={contextValue}>
         {/* 上方 anchor 區域 */}
         <LandlordAnchor refFnList={refFnList} listCount={listCount} />
         {/* 手風琴呈現列表 */}
@@ -277,6 +296,7 @@ export default function HouseList() {
             </AccordionPanel>
           </Accordion>
         </Flowbite>
+      </ForcedChangeReload.Provider>
       </main>
     </>
   );

--- a/src/components/landLordManagement/modals/ForcedChangeModal.tsx
+++ b/src/components/landLordManagement/modals/ForcedChangeModal.tsx
@@ -1,12 +1,15 @@
+import { useNavigate } from "react-router-dom";
 // Model-popup 所需之匯入
 import { Modal } from "flowbite-react";
 import close from "../../../assets/imgs/icons/close.svg";
 import { CustomFlowbiteTheme, Flowbite } from "flowbite-react";
 import { HiOutlineExclamationCircle } from "react-icons/hi";
+import { apiHouseLandlordChangeFinish } from "../../../apis/apis";
 
 interface ForceChangeModalPropsType {
   openForceChangeModal: boolean;
   setOpenForceChangeModal: (value: boolean) => void;
+  setOpenQuickCheckModal: (value: boolean) => void;
 }
 
 export default function ForcedChangeModal(props : ForceChangeModalPropsType) {
@@ -65,7 +68,33 @@ export default function ForcedChangeModal(props : ForceChangeModalPropsType) {
     },
   };
 
-  const { openForceChangeModal, setOpenForceChangeModal } = props;
+  const { openForceChangeModal, setOpenForceChangeModal, setOpenQuickCheckModal } = props;
+  const navigate = useNavigate();
+
+  const forcedChangeAPI = async (houseId: string|null) => {
+    try {
+      console.log(houseId);
+      const response = await apiHouseLandlordChangeFinish(houseId);
+      console.log(response);
+      setOpenForceChangeModal(false);
+      setOpenQuickCheckModal(false);
+      window.location.reload();
+    } catch (error: any) {
+      if (error.response.status === 401) {
+        localStorage.clear();
+        alert("操作失敗，請重新登入(錯誤：401)");
+        navigate("/");
+      } else {
+        console.error("Failed to fetch data:", error);
+      }
+    }
+  }
+  
+  const handleForcedChangeFinish = () => {
+    const houseId = localStorage.getItem("houseId");
+    forcedChangeAPI(houseId);
+  }
+
   return (
     <Flowbite theme={{ theme: customTheme }}>
     <Modal show={openForceChangeModal} size="xl" onClose={() => setOpenForceChangeModal(false)} popup>
@@ -84,7 +113,7 @@ export default function ForcedChangeModal(props : ForceChangeModalPropsType) {
         </div>
         <p className="mb-10 text-sans-body1">若強制更改為已完成，將無法與租客相互評價和下載合約。</p>
         <div className="flex justify-end gap-6">
-          <button type="button" className="outline-button-m" onClick={() => setOpenForceChangeModal(false)}>
+          <button type="button" className="outline-button-m" onClick={handleForcedChangeFinish}>
             確認強制更改
           </button>
           <button type="button" className="filled-button-m" onClick={() => setOpenForceChangeModal(false)}>

--- a/src/components/landLordManagement/modals/ForcedChangeModal.tsx
+++ b/src/components/landLordManagement/modals/ForcedChangeModal.tsx
@@ -75,9 +75,15 @@ export default function ForcedChangeModal(props : ForceChangeModalPropsType) {
     try {
       await apiHouseLandlordChangeFinish(houseId);
       setOpenForceChangeModal(false);
-      setOpenQuickCheckModal(false);
+      if (setOpenQuickCheckModal) {
+        setOpenQuickCheckModal(false);
+      }
       localStorage.removeItem("houseId");
-      window.location.reload();
+      navigate("/landlord",{
+        state: {
+          toastMessage: "房源狀態已更改"
+        }
+      });
     } catch (error: any) {
       if (error.response.status === 401) {
         localStorage.clear();

--- a/src/components/landLordManagement/modals/ForcedChangeModal.tsx
+++ b/src/components/landLordManagement/modals/ForcedChangeModal.tsx
@@ -9,7 +9,7 @@ import { apiHouseLandlordChangeFinish } from "../../../apis/apis";
 interface ForceChangeModalPropsType {
   openForceChangeModal: boolean;
   setOpenForceChangeModal: (value: boolean) => void;
-  setOpenQuickCheckModal: (value: boolean) => void;
+  setOpenQuickCheckModal: ((value: boolean) => void) | null;
 }
 
 export default function ForcedChangeModal(props : ForceChangeModalPropsType) {
@@ -73,11 +73,10 @@ export default function ForcedChangeModal(props : ForceChangeModalPropsType) {
 
   const forcedChangeAPI = async (houseId: string|null) => {
     try {
-      console.log(houseId);
-      const response = await apiHouseLandlordChangeFinish(houseId);
-      console.log(response);
+      await apiHouseLandlordChangeFinish(houseId);
       setOpenForceChangeModal(false);
       setOpenQuickCheckModal(false);
+      localStorage.removeItem("houseId");
       window.location.reload();
     } catch (error: any) {
       if (error.response.status === 401) {

--- a/src/components/landLordManagement/modals/ForcedChangeModal.tsx
+++ b/src/components/landLordManagement/modals/ForcedChangeModal.tsx
@@ -1,3 +1,4 @@
+import { useContext } from "react";
 import { useNavigate } from "react-router-dom";
 // Model-popup 所需之匯入
 import { Modal } from "flowbite-react";
@@ -5,6 +6,7 @@ import close from "../../../assets/imgs/icons/close.svg";
 import { CustomFlowbiteTheme, Flowbite } from "flowbite-react";
 import { HiOutlineExclamationCircle } from "react-icons/hi";
 import { apiHouseLandlordChangeFinish } from "../../../apis/apis";
+import { ForcedChangeReload } from "../index/HouseList";
 
 interface ForceChangeModalPropsType {
   openForceChangeModal: boolean;
@@ -71,11 +73,14 @@ export default function ForcedChangeModal(props : ForceChangeModalPropsType) {
   const { openForceChangeModal, setOpenForceChangeModal, setOpenQuickCheckModal } = props;
   const navigate = useNavigate();
 
+  const { setIsforcedChangeAPITriggered } = useContext(ForcedChangeReload);
+
   const forcedChangeAPI = async (houseId: string|null) => {
     try {
       await apiHouseLandlordChangeFinish(houseId);
       setOpenForceChangeModal(false);
       if (setOpenQuickCheckModal) {
+        setIsforcedChangeAPITriggered(true);
         setOpenQuickCheckModal(false);
       }
       localStorage.removeItem("houseId");
@@ -84,6 +89,7 @@ export default function ForcedChangeModal(props : ForceChangeModalPropsType) {
           toastMessage: "房源狀態已更改"
         }
       });
+      
     } catch (error: any) {
       if (error.response.status === 401) {
         localStorage.clear();

--- a/src/components/landLordManagement/modals/QuickCheckModal.tsx
+++ b/src/components/landLordManagement/modals/QuickCheckModal.tsx
@@ -28,7 +28,10 @@ export default function QuickCheckModal(props : QuickCheckModalPropsType) {
             <img
               src={close} alt="close"
               className="ml-auto cursor-pointer"
-              onClick={() => setOpenModal(false)} 
+              onClick={() => {
+                localStorage.removeItem("houseId");
+                setOpenModal(false)
+              }} 
             />
           </div>
           <p className="mb-8 text-sans-body1">請填入承租資訊及合約起迄時間。</p>
@@ -98,11 +101,17 @@ export default function QuickCheckModal(props : QuickCheckModalPropsType) {
             <div className="flex justify-end gap-6">
               <button
                 type="button" 
-                className="outline-button-m" onClick={() => setOpenModal(false)}
+                className="outline-button-m" onClick={() => {
+                  localStorage.removeItem("houseId");
+                  setOpenModal(false)
+                }}
               >取消</button>
               <button
                 type="button" 
-                className="filled-button-m" onClick={() => setOpenModal(false)}
+                className="filled-button-m" onClick={() => {
+                  localStorage.removeItem("houseId");
+                  setOpenModal(false)
+                }}
               >立即更改</button>
             </div>
           </form>

--- a/src/components/landLordManagement/modals/QuickCheckModal.tsx
+++ b/src/components/landLordManagement/modals/QuickCheckModal.tsx
@@ -96,7 +96,7 @@ export default function QuickCheckModal(props : QuickCheckModalPropsType) {
                 onClick={() => setOpenForceChangeModal(true)}
               >強制更改為已完成</button>
               {/* 點擊強制更改跳出的 Model pop-up */}
-              <ForcedChangeModal openForceChangeModal={openForceChangeModal} setOpenForceChangeModal={setOpenForceChangeModal} />
+              <ForcedChangeModal setOpenQuickCheckModal={setOpenModal} openForceChangeModal={openForceChangeModal} setOpenForceChangeModal={setOpenForceChangeModal} />
             </div>
             <div className="flex justify-end gap-6">
               <button

--- a/src/pages/landlordManagement/LandlordManagement.tsx
+++ b/src/pages/landlordManagement/LandlordManagement.tsx
@@ -4,12 +4,14 @@ import BigLoading from "../../components/loading/BigLoading";
 import Footer from "../../components/footer/Footer";
 import addIcon from "../../assets/imgs/icons/add.svg";
 import { apiHouseLandlordPostNew } from "../../apis/apis";
+import { Toast } from "flowbite-react";
 
 export default function LandlordManagement() {
   const [loading, setLoading] = useState(false);
   const location = useLocation();
   const navigate = useNavigate();
   const [activeButton, setActiveButton] = useState('');
+  const [showToast, setShowToast] = useState(false);
 
   const handlePostNew = async () => {
     // 新增房源
@@ -37,11 +39,25 @@ export default function LandlordManagement() {
     } else if (location.pathname === '/landlord/history') {
       setActiveButton('history');
     }
+
+    // 判斷是否有toast
+    if (location.state) {
+      setShowToast(true);
+      window.history.replaceState({}, document.title);
+    }
   },[location]);
 
   return (
     <>
       {loading && <BigLoading />}
+      {
+        showToast && (
+          <Toast className="shadow-elevation-1 shadow-Neutral-60 w-auto gap-2 fixed bottom-10 left-1/2 -translate-x-1/2 bg-black rounded px-2.5 py-1">
+            <div className="text-white text-sans-body1">{location.state.toastMessage}</div>
+            <Toast.Toggle className="bg-transparent ml-0 focus:ring-0 text-white hover:text-Neutral-60 hover:bg-transparent" />
+          </Toast>
+        )
+      }
       <header className="bg-Landlord-99">
         <div className="container px-8 py-6">
           <h2 className="text-sans-b-h5 mb-5">房東好窩</h2>

--- a/src/pages/landlordManagement/PublishHouse.tsx
+++ b/src/pages/landlordManagement/PublishHouse.tsx
@@ -353,7 +353,10 @@ export default function PublishHouse() {
               <button
                 type="button"
                 className="outline-button-m"
-                onClick={() => navigate("/landlord")}
+                onClick={() => {
+                  localStorage.removeItem("houseId");
+                  navigate("/landlord")
+                }}
               >返回房源管理頁面</button>
               <button type="button" className="outline-button-m">查看合約</button>
               <Tooltip
@@ -373,7 +376,7 @@ export default function PublishHouse() {
           </div>
         </div>
       </header>
-      <ForcedChangeModal openForceChangeModal={openForceChangeModal} setOpenForceChangeModal={setOpenForceChangeModal} />
+      <ForcedChangeModal setOpenQuickCheckModal={null} openForceChangeModal={openForceChangeModal} setOpenForceChangeModal={setOpenForceChangeModal} />
       <main className="container layout-grid">
         <div className="col-span-7 pt-6 pb-52">
           <HouseDatas houseDatas={houseDatas}/>


### PR DESCRIPTION
新增 強制更改房源狀態為已完成 ALO-6
使用到的頁面：
- 房源管理頁面 -> 刊登中房源卡片之快速變更內的強制變更
- 刊登中房源頁面 -> 更改為已承租 offcanvas 內的強制變更
- 刊登中房源頁面 -> 更改為已完成的強制變更

[強制更改房源狀態為已完成 ALO-6](https://smart-governor-e0d.notion.site/ALO-6-17094dce4e5a4779817452f6e481e14e?pvs=4)