### PR TITLE
feature: landLord identity cannot apply for an appointment

### DIFF
--- a/src/pages/SingleHousePage.tsx
+++ b/src/pages/SingleHousePage.tsx
@@ -1347,7 +1347,10 @@ function SingleHousePage() {
                         <button
                           className={`w-full text-sans-b-body1 text-center border-Neutral-90 bg-Brand-90 py-2 rounded-lg shadow-elevation-2 hover:bg-Brand-95 ${
                             singleHouseData.appointmentAvailable === false
-                              ? "cursor-not-allowed"
+                              ? localStorage.getItem("currentIdentity") ===
+                                "landLord"
+                                ? "hidden"
+                                : "cursor-not-allowed"
                               : ""
                           }`}
                           onClick={showTenantInfo}


### PR DESCRIPTION
【修正】
如果是房東身分，在單一房源頁面時，不會顯示「預約看房按鈕」